### PR TITLE
fix: add check before reading a link

### DIFF
--- a/systemscan/main.py
+++ b/systemscan/main.py
@@ -264,8 +264,16 @@ def legacy_inventory(inv):
     for iface in interfaces:
         iface_path = os.path.join('/sys/class/net', iface)
 
-        # don't count virtual devices (lo, bridge) or wifi devices
-        if ('virtual' in os.readlink(iface_path)) or os.path.exists(os.path.join(iface_path, 'phy80211')):
+        # skip if path is not a dir as later we rely on files inside it
+        if not os.path.isdir(iface_path):
+            continue
+
+        # don't count virtual devices (lo, bridge)
+        if (os.path.islink(iface_path) and 'virtual' in os.readlink(iface_path)):
+            continue
+
+        # don't count wifi devices
+        if os.path.exists(os.path.join(iface_path, 'phy80211')):
             continue
 
         with open(os.path.join(iface_path, 'type')) as type_file:


### PR DESCRIPTION
this should eliminate Stacktrace when interface under /sys/class/net is not a
symlink, as now we check before dereferencing to make sure file is a symlink.

BZ182420

Signed-off-by: Matej Dujava <mdujava@redhat.com>